### PR TITLE
Issue#1

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -1,28 +1,14 @@
 package commands
 
-import (
-	"encoding/json"
-)
-
-// A temporary object that contains the packet type and the data to be handled
-// by the server.
-type Envelope struct {
-	Type PacketType      `json:"type"`
-	Data json.RawMessage `json:"data"`
-}
-
 // -----------------------------------------------------------------------------
 
 // The Message itself with fields from the incoming tcp stream and various
 // Mycelia used fields.
 type SendMessage struct {
-	// Unsure if I want this - There should be some primary field.
-	Route string `json:"route"`
-
+	ID     string `json:"id"` // Should be some form of UUID.
+	Route  string `json:"route"`
 	Status Status `json:"status"`
-
-	// The primary payload to send to the consumer.
-	Body map[string]any `json:"body"`
+	Body   string `json:"body"` // The primary payload to send to the consumer.
 }
 
 // -----------------------------------------------------------------------------
@@ -30,6 +16,7 @@ type SendMessage struct {
 // Command to add a new route to the router. Routes are the boxes where channels
 // are organized.
 type RegisterRoute struct {
+	ID   string `json:"id"` // Should be some form of UUID.
 	Name string `json:"name"`
 }
 
@@ -39,6 +26,7 @@ type RegisterRoute struct {
 // to have all messages traveling along a route forwarded to it.
 // From there a Consumer is made and registered to the end channel of a route.
 type AddSubscriber struct {
+	ID      string `json:"id"`      // Should be some form of UUID.
 	Route   string `json:"route"`   // Which route to subscribe to.
 	Channel string `json:"channel"` // Which chnl on the route to subscribe to.
 	Address string `json:"address"` // Where to forward the message.
@@ -47,6 +35,7 @@ type AddSubscriber struct {
 // -----------------------------------------------------------------------------
 
 type AddChannel struct {
+	ID    string `json:"id"` // Should be some form of UUID.
 	Route string `json:"route"`
 	Name  string `json:"name"`
 }

--- a/commands/constants.go
+++ b/commands/constants.go
@@ -13,13 +13,3 @@ const (
 	// A message whose source string could not be properly decoded.
 	StatusInvalid
 )
-
-// What to map the incoming raw data to.
-type PacketType string
-
-const (
-	// Intent to subscribe to a route or channel.
-	TypeSubscriber = "subscribe"
-	// A message that needs to be sent through a route.
-	TypeMessage = "message"
-)

--- a/routing/channel.go
+++ b/routing/channel.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"fmt"
 	"mycelia/commands"
 	"mycelia/utils"
 )
@@ -24,7 +25,8 @@ type Channel struct {
 func (c *Channel) RegisterSubscriber(subscriber *Consumer) {
 	// Temp setup of single array of subscribers.
 	c.subscribers = append(c.subscribers, *subscriber)
-	utils.SprintfLnIndent("AddedSubscriber: %s", 2, subscriber.Address)
+	aMsg := fmt.Sprintf("Added Subscriber %s", subscriber.Address)
+	utils.ActionPrint(aMsg)
 }
 
 func (c *Channel) ProcessMessage(m *commands.SendMessage) *commands.SendMessage {

--- a/routing/consumer.go
+++ b/routing/consumer.go
@@ -1,7 +1,6 @@
 package routing
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 
@@ -23,20 +22,16 @@ func (c *Consumer) ConsumeMessage(m *commands.SendMessage) {
 	fmt.Println("Attempting to dial", c.Address)
 	conn, err := net.Dial("tcp", c.Address)
 	if err != nil {
-		utils.SprintfLnIndent("Could not dial %s", 2, c.Address)
+		wMsg := fmt.Sprintf("Could not dial %s", c.Address)
+		utils.WarningPrint(wMsg)
 		return
 	}
 	defer conn.Close()
 
-	payload, err := json.Marshal(m.Body)
+	_, err = conn.Write([]byte(m.Body))
 	if err != nil {
-		utils.MessageIfError("Error marshaling mesasge body", err)
-		return
-	}
-	_, err = conn.Write([]byte(payload))
-	if err != nil {
-		msg := fmt.Sprintf("Error sending to %s", c.Address)
-		fmt.Println(msg, ": ", err)
+		eMsg := fmt.Sprintf("Error sending to %s", c.Address)
+		utils.ErrorPrint(eMsg)
 		return
 	}
 	m.Status = commands.StatusResolved

--- a/routing/route.go
+++ b/routing/route.go
@@ -41,7 +41,7 @@ func (r *Route) AddChannel(c *commands.AddChannel) *Channel {
 		channel = NewChannel(c.Name)
 		r.Channels = append(r.Channels, *channel)
 		m := fmt.Sprintf("Adding channel: [%s] to route: [%s]", c.Name, r.Name)
-		utils.SprintfLnIndent(m, 2)
+		utils.ActionPrint(m)
 	}
 
 	return channel
@@ -53,7 +53,8 @@ func (r *Route) AddSubscriber(s *commands.AddSubscriber) {
 	channel, err := r.GetChannel(s.Channel)
 	if err != nil {
 		msg := "Error adding subscriber on route: [%s], channel not found: [%s]"
-		utils.SprintfLnIndent(msg, 2, s.Route, s.Channel)
+		eMsg := fmt.Sprintf(msg, s.Route, s.Channel)
+		utils.ErrorPrint(eMsg)
 		return
 	}
 

--- a/routing/router.go
+++ b/routing/router.go
@@ -1,15 +1,22 @@
 package routing
 
 import (
-	"encoding/json"
 	"fmt"
+	"strings"
 
 	"mycelia/commands"
 	"mycelia/utils"
 )
 
+const (
+	CMD_SEND_MESSAGE   = "send_message"
+	CMD_ADD_SUBSCRIBER = "add_subscriber"
+	CMD_ADD_CHANNEL    = "add_channel"
+	CMD_ADD_ROUTE      = "add_route"
+)
+
 // What function gets run, passing in the data field of a command envelope.
-type CommandHandler func(commands.Envelope)
+type CommandHandler func([]string)
 
 // Creates a new router with registered commands. A new router will always
 // contain a route named 'main' that contains no channels.
@@ -18,11 +25,11 @@ func NewRouter() *Router {
 	router.Routes = map[string]*Route{
 		"main": NewRoute("main"),
 	}
-	router.commandRegistry = map[commands.PacketType]CommandHandler{
-		"send_message":   router.SendMessage,
-		"add_subscriber": router.AddSubscriber,
-		"add_channel":    router.AddChannel,
-		"register_route": router.RegisterRoute,
+	router.commandRegistry = map[string]CommandHandler{
+		CMD_SEND_MESSAGE:   router.SendMessage,
+		CMD_ADD_SUBSCRIBER: router.AddSubscriber,
+		CMD_ADD_CHANNEL:    router.AddChannel,
+		CMD_ADD_ROUTE:      router.AddRoute,
 	}
 
 	return &router
@@ -39,50 +46,61 @@ type Router struct {
 
 	// The map of envelope type strings to runnable commands.
 	// The data field of the envolope is passed through to the command handler.
-	commandRegistry map[commands.PacketType]CommandHandler
+	commandRegistry map[string]CommandHandler
 }
 
-func (r *Router) HandleEnvelope(input []byte) {
-	var env commands.Envelope
-	if err := json.Unmarshal(input, &env); err != nil {
-		fmt.Println("Invalid envelop:", err)
-		return
-	}
+func (r *Router) HandleCommand(input []byte) {
+	rawString := string(input)
+	tokens := strings.Split(rawString, ";;")
+	cmd_type := tokens[0]
 
-	cmd, ok := r.commandRegistry[env.Type]
+	cmd, ok := r.commandRegistry[cmd_type]
 	if !ok {
-		msg := fmt.Sprintf("Unknown command type: %s", env.Type)
-		utils.SprintfLnIndent(msg, 2)
+		msg := fmt.Sprintf("Unknown command type: %s", cmd_type)
+		utils.WarningPrint(msg)
 		return
 	}
 
-	cmd(env)
+	cmd(tokens)
 }
 
 // -------Message Handlers------------------------------------------------------
 
-func (r *Router) SendMessage(env commands.Envelope) {
-	var msg commands.SendMessage
-	if err := json.Unmarshal(env.Data, &msg); err != nil {
-		utils.SprintfLnIndent("Invalid message: %s", 2, err.Error())
+func (r *Router) SendMessage(tokens []string) {
+	if len(tokens) != 4 {
+		msg := "send_message command failed, expected 4 args, got %v"
+		errMsg := fmt.Sprintf(msg, len(tokens))
+		utils.WarningPrint(errMsg)
 		return
 	}
 
+	var msg commands.SendMessage
 	msg.Status = commands.StatusCreated
+	msg.ID = tokens[1]
+	msg.Route = tokens[2]
+	msg.Body = tokens[3]
+
 	route, exists := r.Routes[msg.Route]
 	if !exists {
-		utils.SprintfLnIndent("Route not found: %s", 2, msg.Route)
+		wMsg := fmt.Sprintf("Route not found: %s", msg.Route)
+		utils.WarningPrint(wMsg)
 		return
 	}
 	route.ProcessMessage(&msg)
 }
 
-func (r *Router) RegisterRoute(env commands.Envelope) {
-	var reg commands.RegisterRoute
-	if err := json.Unmarshal(env.Data, &reg); err != nil {
-		utils.SprintfLnIndent("Invalid route: %s", 2, err.Error())
+func (r *Router) AddRoute(tokens []string) {
+	if len(tokens) != 3 {
+		msg := "add_route command failed, expected 3 args, got %v"
+		errMsg := fmt.Sprintf(msg, len(tokens))
+		utils.WarningPrint(errMsg)
 		return
 	}
+
+	var reg commands.RegisterRoute
+	reg.ID = tokens[1]
+	reg.Name = tokens[2]
+
 	_, exists := r.Routes[reg.Name]
 	if !exists {
 		route := NewRoute(reg.Name)
@@ -90,32 +108,51 @@ func (r *Router) RegisterRoute(env commands.Envelope) {
 		utils.SprintfLn("Route %s registered!", reg.Name)
 		return
 	}
-	utils.SprintfLn("Route %s already exists.", reg.Name)
+
+	wMsg := fmt.Sprintf("Route %s already exists.", reg.Name)
+	utils.WarningPrint(wMsg)
 }
 
-func (r *Router) AddChannel(env commands.Envelope) {
-	var ch commands.AddChannel
-	if err := json.Unmarshal(env.Data, &ch); err != nil {
-		utils.SprintfLnIndent("Invalid channel %s", 2, err.Error())
+func (r *Router) AddChannel(tokens []string) {
+	if len(tokens) != 4 {
+		msg := "add_channel command failed, expected 4 args, got %v"
+		errMsg := fmt.Sprintf(msg, len(tokens))
+		utils.WarningPrint(errMsg)
 		return
 	}
+
+	var ch commands.AddChannel
+	ch.ID = tokens[1]
+	ch.Route = tokens[2]
+	ch.Name = tokens[3]
+
 	route, exists := r.Routes[ch.Route]
 	if !exists {
-		utils.SprintfLnIndent("Route not found %s", 2, ch.Route)
+		wMsg := fmt.Sprintf("Route not found %s", ch.Route)
+		utils.WarningPrint(wMsg)
 		return
 	}
 	route.AddChannel(&ch)
 }
 
-func (r *Router) AddSubscriber(env commands.Envelope) {
-	var sub commands.AddSubscriber
-	if err := json.Unmarshal(env.Data, &sub); err != nil {
-		utils.SprintfLnIndent("Invalid subscription: %s", 2, err.Error())
+func (r *Router) AddSubscriber(tokens []string) {
+	if len(tokens) != 5 {
+		msg := "add_channel command failed, expected 5 args, got %v"
+		errMsg := fmt.Sprintf(msg, len(tokens))
+		utils.WarningPrint(errMsg)
 		return
 	}
+
+	var sub commands.AddSubscriber
+	sub.ID = tokens[1]
+	sub.Route = tokens[2]
+	sub.Channel = tokens[3]
+	sub.Address = tokens[4]
+
 	route, exists := r.Routes[sub.Route]
 	if !exists {
-		utils.SprintfLnIndent("Route not found %s", 2, sub.Route)
+		wMsg := fmt.Sprintf("Route not found %s", sub.Route)
+		utils.WarningPrint(wMsg)
 		return
 	}
 	route.AddSubscriber(&sub)

--- a/server/server.go
+++ b/server/server.go
@@ -56,7 +56,7 @@ func (server *Server) handleConnection(conn net.Conn) {
 		message, err := reader.ReadString('\n')
 
 		if len(message) > 0 {
-			go server.router.HandleEnvelope([]byte(message))
+			go server.router.HandleCommand([]byte(message))
 		}
 
 		if err == nil {

--- a/utils/str.go
+++ b/utils/str.go
@@ -4,7 +4,6 @@ package utils
 
 import (
 	"fmt"
-	"strings"
 )
 
 func SprintfLn(formatStr string, args ...string) {
@@ -12,21 +11,22 @@ func SprintfLn(formatStr string, args ...string) {
 	fmt.Println(msg)
 }
 
-// Same as utils.SprintfLn but will add "  - " to the start of the string with
-// spaces equal to the indent number.
-func SprintfLnIndent(formatStr string, indent int, args ...string) {
-	imsg := strings.Repeat(" ", indent) + "- " + formatStr
+func ActionPrint(s string) {
+	msg := fmt.Sprintf("[ACTION] - %s", s)
+	fmt.Println(msg)
+}
 
-	var anyArgs []any = make([]any, len(args))
-	for i, v := range args {
-		anyArgs[i] = v
-	}
+func ErrorPrint(s string) {
+	msg := fmt.Sprintf("[ERROR] - %s", s)
+	fmt.Println(msg)
+}
 
-	msg := fmt.Sprintf(imsg, anyArgs...)
+func WarningPrint(s string) {
+	msg := fmt.Sprintf("[WARNING] - %s", s)
 	fmt.Println(msg)
 }
 
 func DebugPrintLn(s string) {
-	msg := fmt.Sprintf("[DEBUG] %s", s)
+	msg := fmt.Sprintf("[DEBUG] - %s", s)
 	fmt.Println(msg)
 }


### PR DESCRIPTION
fixes #1 

This creates a simple delimiter joined string object to parse rather than using json marshaling in the standard go library as the json standard is slower than most other parsing techniques.

This also gives us the added benefit of not caring about message body structure, letting us use pure strings so users can format in any format they wish, e.g. xml, yaml, json, etc, and the system makes no assumptions on the underlying structure of the message body field.

Additionally this also cleans up some of the utility prints.